### PR TITLE
Fix: Prevent item respawn after clear

### DIFF
--- a/src/main/java/com/minekarta/advancedcorehub/actions/types/ClearAction.java
+++ b/src/main/java/com/minekarta/advancedcorehub/actions/types/ClearAction.java
@@ -2,7 +2,9 @@ package com.minekarta.advancedcorehub.actions.types;
 
 import com.minekarta.advancedcorehub.AdvancedCoreHub;
 import com.minekarta.advancedcorehub.actions.Action;
+import com.minekarta.advancedcorehub.util.PersistentKeys;
 import org.bukkit.entity.Player;
+import org.bukkit.persistence.PersistentDataType;
 
 public class ClearAction implements Action {
 
@@ -15,5 +17,6 @@ public class ClearAction implements Action {
     @Override
     public void execute(Player player, String data) {
         player.getInventory().clear();
+        player.getPersistentDataContainer().set(PersistentKeys.INVENTORY_CLEARED, PersistentDataType.BYTE, (byte) 1);
     }
 }

--- a/src/main/java/com/minekarta/advancedcorehub/listeners/PlayerJoinListener.java
+++ b/src/main/java/com/minekarta/advancedcorehub/listeners/PlayerJoinListener.java
@@ -1,11 +1,13 @@
 package com.minekarta.advancedcorehub.listeners;
 
 import com.minekarta.advancedcorehub.AdvancedCoreHub;
+import com.minekarta.advancedcorehub.util.PersistentKeys;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.persistence.PersistentDataType;
 
 import java.util.List;
 
@@ -31,7 +33,9 @@ public class PlayerJoinListener implements Listener {
         }
 
         // 3. Handle Hub Inventory
-        if (plugin.getInventoryManager().isHubWorld(player.getWorld().getName())) {
+        if (player.getPersistentDataContainer().has(PersistentKeys.INVENTORY_CLEARED, PersistentDataType.BYTE)) {
+            player.getPersistentDataContainer().remove(PersistentKeys.INVENTORY_CLEARED);
+        } else if (plugin.getInventoryManager().isHubWorld(player.getWorld().getName())) {
             plugin.getInventoryManager().setupHubInventory(player);
         }
 

--- a/src/main/java/com/minekarta/advancedcorehub/util/PersistentKeys.java
+++ b/src/main/java/com/minekarta/advancedcorehub/util/PersistentKeys.java
@@ -26,4 +26,7 @@ public final class PersistentKeys {
 
     // Key for timed flight expiration
     public static final NamespacedKey FLY_EXPIRATION = new NamespacedKey(plugin, "fly_expiration");
+
+    // Key to prevent item giving on join after inventory clear
+    public static final NamespacedKey INVENTORY_CLEARED = new NamespacedKey(plugin, "inventory_cleared");
 }


### PR DESCRIPTION
Implements a mechanism to prevent hub items from being automatically re-issued to a player if they rejoin the server immediately after their inventory has been cleared.

- Adds a persistent data tag (`inventory_cleared`) to a player when the `ClearAction` is used.
- The `PlayerJoinListener` now checks for this tag upon player join.
- If the tag is present, it is removed, and the `setupHubInventory` process is skipped for that join, preventing the items from being given again. This tag is for a single use.