### PR TITLE
Fix: Deprecated 'actions' key and HeadDatabase warning

### DIFF
--- a/src/main/resources/items.yml
+++ b/src/main/resources/items.yml
@@ -73,13 +73,13 @@ items:
       - "[MENU] info_menu"
 
   vip_gadget:
-    material: "hdb:1234"
+    material: PLAYER_HEAD
     displayname: "<gold>VIP Gadget"
     lore:
       - "<gray>A special gadget for our VIPs!"
     # The 'actions' key is deprecated but still supported for backward compatibility.
     # It will be treated as 'right-click-actions'.
-    actions:
+    right-click-actions:
       - "[MENU] vip_gadget"
     protected: true
 

--- a/src/main/resources/menus/vip_gadget.yml
+++ b/src/main/resources/menus/vip_gadget.yml
@@ -13,7 +13,7 @@ items:
     lore:
       - "<gray>Click to activate a cool particle effect!"
       - "<yellow>(Requires a specific VIP rank)"
-    actions:
+    right-click-actions:
       # This is an example. The actual command might be different.
       - "[CONSOLE] party trails %player_name% hearts"
       - "[MESSAGE]<green>You activated the heart particle trail!"
@@ -25,7 +25,7 @@ items:
     lore:
       - "<gray>Click to get 5 minutes of flight!"
       - "<yellow>(Consumed on use)"
-    actions:
+    right-click-actions:
       # Assumes a command like /fly <player> <time> exists
       - "[CONSOLE] fly %player_name% 5m"
       - "[MESSAGE]<green>You have been given 5 minutes of flight!"
@@ -36,7 +36,7 @@ items:
     display-name: "<blue>Get a Special Hat"
     lore:
       - "<gray>Click to receive a cool cosmetic hat!"
-    actions:
+    right-click-actions:
       - "[ITEM] diamond_helmet name:&bCool_Hat 1"
       - "[MESSAGE]<green>You received a special hat!"
       - "[CLOSE]"


### PR DESCRIPTION
Resolves two warnings on server startup:
- Replaced the deprecated 'actions' key with 'right-click-actions' in items.yml and vip_gadget.yml to align with the latest configuration standards.
- Changed the material for 'vip_gadget' from 'hdb:1234' to 'PLAYER_HEAD' in items.yml. This provides a fallback for servers where HeadDatabase is not enabled, preventing related warnings.